### PR TITLE
Fix issue #1

### DIFF
--- a/frontend/components/OptionsPanel.js
+++ b/frontend/components/OptionsPanel.js
@@ -103,7 +103,7 @@ const OptionsPanel = ({ httpClient }) => {
             />
             {validationErrors.number_songs && (
               <div className="text-sm text-red-600">
-                Must be a number from 1 to 100
+                Must be a number from 1 to 50
               </div>
             )}
           </div>


### PR DESCRIPTION
# Changelog
* Fix bug noted in #1 where options panel displays wrong bounds in error message

# Notes
As was noted in the initial bug fix, this is related to the fact that Spotify limits the number of tracks that can be requested without paging to 50. The error message on the options panel was likely created before this technical limitation was taken into account, and never updated.